### PR TITLE
Extract code from cases into switch

### DIFF
--- a/islandora_badges.module
+++ b/islandora_badges.module
@@ -54,7 +54,7 @@ function islandora_badges_block_info() {
 function islandora_badges_block_view($delta) {
   $to_render = array();
 
-  // Move 'Get DOI' bits out of the switch
+  // Get object metadata - i.e. DOI
   $object = menu_get_object('islandora_object', 2);
       // Get DOI.
   if (!isset($object['MODS'])) {
@@ -78,26 +78,6 @@ function islandora_badges_block_view($delta) {
   switch ($delta) {
     // Load the Altmetrics block
     case 'islandora_badges_altmetrics':
-/*      $object = menu_get_object('islandora_object', 2);
-      // Get DOI.
-      if (!isset($object['MODS'])) {
-        return;
-      }
-      $doc = new DOMDocument();
-      $doc->loadXML($object['MODS']->content);
-      $xpath = new DOMXPath($doc);
-      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-      $xpath_results = $xpath->query(
-        variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]')
-      );
-      if ($xpath_results->length == 0) {
-        return;
-      }
-      $doi = $xpath_results->item(0)->nodeValue;
-      if (!$doi) {
-        return;
-      }
-*/
       // Embed Altmetrics.
       $to_render['content']['altmetrics'] = array(
         '#type' => 'container',
@@ -114,26 +94,6 @@ function islandora_badges_block_view($delta) {
  
   // Load the Scopus block
    case 'islandora_badges_scopus':
-  /*    $object = menu_get_object('islandora_object', 2);
-      // Get DOI.
-      if (!isset($object['MODS'])) {
-        return;
-      }
-      $doc = new DOMDocument();
-      $doc->loadXML($object['MODS']->content);
-      $xpath = new DOMXPath($doc);
-      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-      $xpath_results = $xpath->query(
-        variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]')
-      );
-      if ($xpath_results->length == 0) {
-        return;
-      }
-      $doi = $xpath_results->item(0)->nodeValue;
-      if (!$doi) {
-        return;
-      }
-*/
       // Embed Scopus.
       // Assemble the Scopus API request URL
       $api_key = variable_get('islandora_badges_scopus_api_key', 'b3a71de2bde04544495881ed9d2f9c5b');
@@ -151,27 +111,6 @@ function islandora_badges_block_view($delta) {
 
 /** Web of Science block */
    case 'islandora_badges_wos':
-/*      $object = menu_get_object('islandora_object', 2);
-      // Limit to citations with MODS DS -- see above.
-      if (!in_array('ir:citationCModel', $object->models) || !isset($object['MODS'])) {
-        return;
-       }
-      // Get DOI.
-      $doc = new DOMDocument();
-      $doc->loadXML($object['MODS']->content);
-      $xpath = new DOMXPath($doc);
-      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
-      $xpath_results = $xpath->query(
-        variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]')
-      );
-      if ($xpath_results->length == 0) {
-        return;
-      }
-      $doi = $xpath_results->item(0)->nodeValue;
-      if (!$doi) {
-        return;
-      }
-*/ 
     // Embed Web of Science.
 
     // Get the WoS AMR username and password from the admin config.
@@ -182,56 +121,55 @@ function islandora_badges_block_view($delta) {
     $url = "https://ws.isiknowledge.com/cps/xrpc";
 
 
-//Store your XML Request in a string - not ideal but I don't know how to send an XML file by POST (ha ha)
+    //Store your XML Request in a string - not ideal but I don't know how to send an XML file by POST (ha ha)
       $input_xml = '<?xml version="1.0" encoding="UTF-8" ?>
       <request xmlns="http://www.isinet.com/xrpc42" src="app.id=API Demo">
-      <fn name="LinksAMR.retrieve">
-      <list>
-      <!-- WHO IS REQUESTING -->
-      <map>   
-          <val name="username">' . $wos_username . '</val>       
-          <val name="password">' . $wos_password . '</val>            
-        </map>
-        <!-- WHAT IS REQUESTED -->
-        <map>
-          <list name="WOS">
-            <val>timesCited</val>
-            <val>citingArticlesURL</val>
+        <fn name="LinksAMR.retrieve">
+          <list>
+            <!-- WHO IS REQUESTING -->
+            <map>   
+              <val name="username">' . $wos_username . '</val>       
+              <val name="password">' . $wos_password . '</val>            
+            </map>
+            <!-- WHAT IS REQUESTED -->
+            <map>
+              <list name="WOS">
+                <val>timesCited</val>
+                <val>citingArticlesURL</val>
+              </list>
+            </map>
+            <!-- LOOKUP DATA -->
+            <map>  
+              <map name="cite_1">
+                <val name="doi">' . $doi . '</val>
+              </map>
+            </map>
           </list>
-        </map>
-        <!-- LOOKUP DATA -->
-        <map>  
-          <map name="cite_1">
-            <val name="doi">' . $doi . '</val>
-          </map>
-        </map>
-      </list>
-    </fn>
-  </request>';
+        </fn>
+      </request>';
 
-// Post the request and get results!
+    // Post the request and get results!
       
-$result = drupal_http_request($url, array(
-  'headers' => array('Content-Type' => 'text/xml'),
-  'data' => $input_xml,
-  'method' => 'POST',
-  'timeout' => 10
-));
+    $result = drupal_http_request($url, array(
+      'headers' => array('Content-Type' => 'text/xml'),
+      'data' => $input_xml,
+      'method' => 'POST',
+      'timeout' => 10
+    ));
 
-// Convert the response to an array and remove the CDATA tags
+    // Convert the response to an array and remove the CDATA tags
 
-$wos_result = simplexml_load_string($result->data, 'SimpleXMLElement', LIBXML_NOCDATA);
+    $wos_result = simplexml_load_string($result->data, 'SimpleXMLElement', LIBXML_NOCDATA);
 
+    // Default - zero citations -- should this really be present?
+    $timesCited = 0;
 
-// Default - zero citations -- should this really be present?
-$timesCited = 0;
+    // Default - citingArticlesURL - no citing articles = empty array
+    $citingArticlesURL = array();
 
-// Default - citingArticlesURL - no citing articles = empty array
-$citingArticlesURL = array();
+    // Get the values into the variables
 
-// Get the values into the variables
-
-foreach ($wos_result->fn->map->map->map->val as $val) {
+    foreach ($wos_result->fn->map->map->map->val as $val) {
 	switch((string) $val['name']) { // Get attributes as element indices
 		case 'timesCited':
 			$timesCited = $val[0];
@@ -247,11 +185,11 @@ foreach ($wos_result->fn->map->map->map->val as $val) {
 		}
 	}
 
-// If there is no error return data
-  if (empty($result ->error)) {
-      $to_render['content'] = '<div class="wos_badge"><a href="' . $citingArticlesURL . '" target="_blank">Web of Science citations: ' . $timesCited . '</a></div>';
-  }
+    // If there is no error return data
+      if (empty($result ->error)) {
+          $to_render['content'] = '<div class="wos_badge"><a href="' . $citingArticlesURL . '" target="_blank">Web of Science citations: ' . $timesCited . '</a></div>';
+      }
       
-}
+    }
   return $to_render;
 }

--- a/islandora_badges.module
+++ b/islandora_badges.module
@@ -53,10 +53,32 @@ function islandora_badges_block_info() {
  
 function islandora_badges_block_view($delta) {
   $to_render = array();
+
+  // Move 'Get DOI' bits out of the switch
+  $object = menu_get_object('islandora_object', 2);
+      // Get DOI.
+  if (!isset($object['MODS'])) {
+      return;
+     }
+    $doc = new DOMDocument();
+    $doc->loadXML($object['MODS']->content);
+    $xpath = new DOMXPath($doc);
+    $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+    $xpath_results = $xpath->query(
+      variable_get('islandora_badges_doi_xpath', '/mods:mods/mods:identifier[@type="doi"]')
+    );
+    if ($xpath_results->length == 0) {
+      return;
+    }
+    $doi = $xpath_results->item(0)->nodeValue;
+    if (!$doi) {
+      return;
+    }
+
   switch ($delta) {
     // Load the Altmetrics block
     case 'islandora_badges_altmetrics':
-      $object = menu_get_object('islandora_object', 2);
+/*      $object = menu_get_object('islandora_object', 2);
       // Get DOI.
       if (!isset($object['MODS'])) {
         return;
@@ -75,7 +97,7 @@ function islandora_badges_block_view($delta) {
       if (!$doi) {
         return;
       }
-
+*/
       // Embed Altmetrics.
       $to_render['content']['altmetrics'] = array(
         '#type' => 'container',
@@ -92,7 +114,7 @@ function islandora_badges_block_view($delta) {
  
   // Load the Scopus block
    case 'islandora_badges_scopus':
-      $object = menu_get_object('islandora_object', 2);
+  /*    $object = menu_get_object('islandora_object', 2);
       // Get DOI.
       if (!isset($object['MODS'])) {
         return;
@@ -111,7 +133,7 @@ function islandora_badges_block_view($delta) {
       if (!$doi) {
         return;
       }
-
+*/
       // Embed Scopus.
       // Assemble the Scopus API request URL
       $api_key = variable_get('islandora_badges_scopus_api_key', 'b3a71de2bde04544495881ed9d2f9c5b');
@@ -129,7 +151,7 @@ function islandora_badges_block_view($delta) {
 
 /** Web of Science block */
    case 'islandora_badges_wos':
-      $object = menu_get_object('islandora_object', 2);
+/*      $object = menu_get_object('islandora_object', 2);
       // Limit to citations with MODS DS -- see above.
       if (!in_array('ir:citationCModel', $object->models) || !isset($object['MODS'])) {
         return;
@@ -149,7 +171,7 @@ function islandora_badges_block_view($delta) {
       if (!$doi) {
         return;
       }
- 
+*/ 
     // Embed Web of Science.
 
     // Get the WoS AMR username and password from the admin config.


### PR DESCRIPTION
Makes the code a lot clearer and more efficient by removing redundant code. Previously, get doi code was implemented in each case. Now that's been moved outside to before cases are called on, meaning that the DOI only need to be extracted once.
