### PR TITLE
Add oaDOI badge submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## Introduction
 
-Islandora Badges displays various metrics badges on objects. Each badge is created by a submodule. Available badges include:
+Islandora Badges displays various metrics (and other) badges on objects. Each badge is created by a submodule. Available badges include:
 * Altmetrics: display social media interactions
 * Scopus: Citation counts via the Scopus database
 * Web of Science: Citation counts via Web of Science
+* oaDOI: Provides a link to a fulltext document for objects without a PDF datastream, via the oadoi.org API
 
 Badges will only display on objects that have a DOI (digital object identifier). The xpath to the DOI field is configurable.
 

--- a/modules/islandora_oadoi/README.md
+++ b/modules/islandora_oadoi/README.md
@@ -22,6 +22,8 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Configuration path is admin/islandora/tools/badges/wos (Administration > Islandora > Islandora Utility Modules > Islandora Badges Configuration > oaDOI).
 
+Link text: Defines the text used in the PDF link. Defaults to "Link to PDF".
+
 ## Styling
 The link text is enclosed in a block with the class "oadoi". This can be styled with CSS.
 

--- a/modules/islandora_oadoi/includes/admin.form.inc
+++ b/modules/islandora_oadoi/includes/admin.form.inc
@@ -3,7 +3,7 @@
  * @file
  * oaDOI badge admin options
  */
-function islandora_oaidoi_admin_form($form, $form_settings) {
+function islandora_oadoi_admin_form($form, $form_settings) {
   $form['islandora_oai_linktext'] = array(
     '#type' => 'textfield',
     '#title' => t('Link text'),

--- a/modules/islandora_oadoi/includes/admin.form.inc
+++ b/modules/islandora_oadoi/includes/admin.form.inc
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * oaDOI badge admin options
+ */
+function islandora_oaidoi_admin_form($form, $form_settings) {
+  $form['islandora_oai_placeholder'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Placeholder field'),
+    '#description' => t('Placeholder field.'),
+    '#default_value' => variable_get('islandora_oai_placeholder', ''),
+  );
+  return system_settings_form($form);
+}

--- a/modules/islandora_oadoi/includes/admin.form.inc
+++ b/modules/islandora_oadoi/includes/admin.form.inc
@@ -4,11 +4,11 @@
  * oaDOI badge admin options
  */
 function islandora_oaidoi_admin_form($form, $form_settings) {
-  $form['islandora_oai_placeholder'] = array(
+  $form['islandora_oai_linktext'] = array(
     '#type' => 'textfield',
-    '#title' => t('Placeholder field'),
-    '#description' => t('Placeholder field.'),
-    '#default_value' => variable_get('islandora_oai_placeholder', ''),
+    '#title' => t('Link text'),
+    '#description' => t('Text to use when generating external download link.'),
+    '#default_value' => variable_get('islandora_oai_linktext', 'Link to PDF'),
   );
   return system_settings_form($form);
 }

--- a/modules/islandora_oadoi/islandora_oadoi.info
+++ b/modules/islandora_oadoi/islandora_oadoi.info
@@ -1,0 +1,6 @@
+name = Islandora oaDOI
+version = 7.x-dev
+core = 7.x
+description = Islandora oaDOI linking.
+dependencies[] = islandora_badges
+package = Islandora Tools

--- a/modules/islandora_oadoi/islandora_oadoi.install
+++ b/modules/islandora_oadoi/islandora_oadoi.install
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * Installation hooks for oaDOI badges.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function islandora_oadoi_uninstall() {
+  $vars = array(
+  );
+  array_walk($vars, 'variable_del');
+}

--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -43,95 +43,34 @@ function islandora_oadoi_block_view($delta = '') {
   $to_render = array();
 
   if ($delta == 'islandora_oadoi_badge') {
-    // Get variables from the admin config.
-  //  $wos_username = variable_get('islandora_wos_username', '');
-  //  $wos_password = variable_get('islandora_wos_password', '');
-  //  if (!empty($wos_username) && !empty($wos_password)) {
-      $object = menu_get_object('islandora_object', 2);
-      if ($object) {
-        $doi = islandora_badges_get_doi($object);
-        if ($doi) {
-          // Set API endpoint URL
-          // @TODO: Add to admin form
-          $url = "https://api.oadoi.org/";
-          $request_url = $url . $doi;
+    $object = menu_get_object('islandora_object', 2);
+    if ($object) {
 
-/* old code from Web of Science requesting - see if anything to recycle
+// To do: Check for PDF datastream; only run if PDF does not exist
+// To do: Check for cmodel
 
-          $input_xml = '<?xml version="1.0" encoding="UTF-8" ?>
-      <request xmlns="http://www.isinet.com/xrpc42" src="app.id=API Demo">
-        <fn name="LinksAMR.retrieve">
-          <list>
-            <!-- WHO IS REQUESTING -->
-            <map>   
-              <val name="username">' . $wos_username . '</val>       
-              <val name="password">' . $wos_password . '</val>            
-            </map>
-            <!-- WHAT IS REQUESTED -->
-            <map>
-              <list name="WOS">
-                <val>timesCited</val>
-                <val>citingArticlesURL</val>
-              </list>
-            </map>
-            <!-- LOOKUP DATA -->
-            <map>  
-              <map name="cite_1">
-                <val name="doi">' . $doi . '</val>
-              </map>
-            </map>
-          </list>
-        </fn>
-      </request>';
-*/
-          // Make the request and get results!
+      $doi = islandora_badges_get_doi($object);
+      if ($doi) {
+         // Set API endpoint URL
+         // @TODO: Add to admin form
+        $url = "https://api.oadoi.org/";
+        $request_url = $url . $doi;
 
-          $result = drupal_http_request($request_url, array(
-            'headers' => array('Content-Type' => 'text/xml'),
-          //  'data' => $input_xml,
-            'method' => 'GET',
-            'timeout' => 10
-          ));
+         // Make the request and get results!
 
-          // Convert the response to an array and remove the CDATA tags
+        $result_json = file_get_contents($request_url);
 
-          $oadoi_result = simplexml_load_string($result->data, 'SimpleXMLElement', LIBXML_NOCDATA);
+        $result_array = json_decode($result_json, TRUE);
 
-          // Default - citingArticlesURL - no citing articles = empty array
-        //  $citingArticlesURL = array();
+        $result_free_url = $result_array['results'][0]['free_fulltext_url'];
 
-          // Get the values into the variables
-/*
-          foreach ($oadoi_result->fn->map->map->map->val as $val) {
-            switch ((string) $val['name']) { // Get attributes as element indices
-              case 'timesCited':
-                $timesCited = $val[0];
-                break;
-              case 'citingArticlesURL':
-                // URL is child node of <val name="citingArticlesURL"> in CDATA section.
-                // We need to pull this out.
-                // Possible that there could be multiple citingArticlesURL values and thus needs an array... Is this true?
-
-                $citingArticlesURL = $val[0];
-
-                break;
-            }
-          }  */
-     /*     // If there is no error return data
-          if ($timesCited > 0) {
-            if (empty($result->error)) {
-              $badgeType = variable_get('islandora_wos_badgetype');
-              if ($badgeType == 'text') {
-                $to_render['content'] = '<div class="wos_badge"><a href="' . $citingArticlesURL . '" target="_blank">Web of Science citations: ' . $timesCited . '</a></div>';
-              }
-              else {
-                $to_render['content'] = '<a href="' . $citingArticlesURL . '" target="_blank"><img src=https://img.shields.io/badge/Web%20of%20Science%20citations-' . $timesCited . '-orange.svg?style=flat"></img></a>';
-              }
-            }
-          } */
-        }
       }
     }
+  }
+
+  if (isset($result_free_url)){
+    $link_text = variable_get('islandora_oai_linktext', 'Link to PDF');
+    $to_render['content'] = '<div class="oadoi"><a href="' . $result_free_url . '" target="_blank">' . $link_text . '</a></div>';        
   }
   return $to_render;
 }

--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -1,0 +1,137 @@
+<?php
+/**
+ * @file
+ * oaDOI Badges
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function islandora_oadoi_menu() {
+  return array(
+    'admin/islandora/tools/badges/oadoi' => array(
+      'title' => 'oaDOI',
+      'description' => 'Configure oaDOI settings.',
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('islandora_oadoi_admin_form'),
+      'access arguments' => array('administer site configuration'),
+      'type' => MENU_LOCAL_TASK,
+      'file' => 'includes/admin.form.inc',
+    ),
+  );
+}
+
+/**
+ * Implements hook_block_info().
+ * @return array
+ */
+function islandora_oadoi_block_info() {
+  return array(
+  'islandora_oadoi_badge' => array(
+    'visibility' => BLOCK_VISIBILITY_LISTED,
+    'pages' => 'islandora/object/*',
+    'cache' => DRUPAL_CACHE_PER_PAGE,
+    'info' => t('Islandora oaDOI Link'),
+  ));
+}
+
+/**
+ * Implements hook_block_view().
+ */
+function islandora_oadoi_block_view($delta = '') {
+  module_load_include('inc', 'islandora_badges', 'includes/utilities');
+  $to_render = array();
+
+  if ($delta == 'islandora_oadoi_badge') {
+    // Get variables from the admin config.
+  //  $wos_username = variable_get('islandora_wos_username', '');
+  //  $wos_password = variable_get('islandora_wos_password', '');
+  //  if (!empty($wos_username) && !empty($wos_password)) {
+      $object = menu_get_object('islandora_object', 2);
+      if ($object) {
+        $doi = islandora_badges_get_doi($object);
+        if ($doi) {
+          // Set API endpoint URL
+          // @TODO: Add to admin form
+          $url = "https://api.oadoi.org/";
+          $request_url = $url . $doi;
+
+/* old code from Web of Science requesting - see if anything to recycle
+
+          $input_xml = '<?xml version="1.0" encoding="UTF-8" ?>
+      <request xmlns="http://www.isinet.com/xrpc42" src="app.id=API Demo">
+        <fn name="LinksAMR.retrieve">
+          <list>
+            <!-- WHO IS REQUESTING -->
+            <map>   
+              <val name="username">' . $wos_username . '</val>       
+              <val name="password">' . $wos_password . '</val>            
+            </map>
+            <!-- WHAT IS REQUESTED -->
+            <map>
+              <list name="WOS">
+                <val>timesCited</val>
+                <val>citingArticlesURL</val>
+              </list>
+            </map>
+            <!-- LOOKUP DATA -->
+            <map>  
+              <map name="cite_1">
+                <val name="doi">' . $doi . '</val>
+              </map>
+            </map>
+          </list>
+        </fn>
+      </request>';
+*/
+          // Make the request and get results!
+
+          $result = drupal_http_request($request_url, array(
+            'headers' => array('Content-Type' => 'text/xml'),
+          //  'data' => $input_xml,
+            'method' => 'GET',
+            'timeout' => 10
+          ));
+
+          // Convert the response to an array and remove the CDATA tags
+
+          $oadoi_result = simplexml_load_string($result->data, 'SimpleXMLElement', LIBXML_NOCDATA);
+
+          // Default - citingArticlesURL - no citing articles = empty array
+        //  $citingArticlesURL = array();
+
+          // Get the values into the variables
+/*
+          foreach ($oadoi_result->fn->map->map->map->val as $val) {
+            switch ((string) $val['name']) { // Get attributes as element indices
+              case 'timesCited':
+                $timesCited = $val[0];
+                break;
+              case 'citingArticlesURL':
+                // URL is child node of <val name="citingArticlesURL"> in CDATA section.
+                // We need to pull this out.
+                // Possible that there could be multiple citingArticlesURL values and thus needs an array... Is this true?
+
+                $citingArticlesURL = $val[0];
+
+                break;
+            }
+          }  */
+     /*     // If there is no error return data
+          if ($timesCited > 0) {
+            if (empty($result->error)) {
+              $badgeType = variable_get('islandora_wos_badgetype');
+              if ($badgeType == 'text') {
+                $to_render['content'] = '<div class="wos_badge"><a href="' . $citingArticlesURL . '" target="_blank">Web of Science citations: ' . $timesCited . '</a></div>';
+              }
+              else {
+                $to_render['content'] = '<a href="' . $citingArticlesURL . '" target="_blank"><img src=https://img.shields.io/badge/Web%20of%20Science%20citations-' . $timesCited . '-orange.svg?style=flat"></img></a>';
+              }
+            }
+          } */
+        }
+      }
+    }
+  }
+  return $to_render;
+}

--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -48,22 +48,24 @@ function islandora_oadoi_block_view($delta = '') {
 
 // To do: Check for PDF datastream; only run if PDF does not exist
 // To do: Check for cmodel
+      if (islandora_badges_show_for_cmodel($object)) {
 
-      $doi = islandora_badges_get_doi($object);
-      if ($doi) {
+
+        $doi = islandora_badges_get_doi($object);
+        if ($doi) {
          // Set API endpoint URL
          // @TODO: Add to admin form
-        $url = "https://api.oadoi.org/";
-        $request_url = $url . $doi;
+          $url = "https://api.oadoi.org/";
+          $request_url = $url . $doi;
 
          // Make the request and get results!
 
-        $result_json = file_get_contents($request_url);
+          $result_json = file_get_contents($request_url);
 
-        $result_array = json_decode($result_json, TRUE);
+          $result_array = json_decode($result_json, TRUE);
 
-        $result_free_url = $result_array['results'][0]['free_fulltext_url'];
-
+          $result_free_url = $result_array['results'][0]['free_fulltext_url'];
+        }
       }
     }
   }

--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -47,24 +47,26 @@ function islandora_oadoi_block_view($delta = '') {
     if ($object) {
 
 // To do: Check for PDF datastream; only run if PDF does not exist
-// To do: Check for cmodel
+
+      // Check CModel against Badges configuration
       if (islandora_badges_show_for_cmodel($object)) {
+        if (!$object['PDF']){
 
-
-        $doi = islandora_badges_get_doi($object);
-        if ($doi) {
-         // Set API endpoint URL
-         // @TODO: Add to admin form
-          $url = "https://api.oadoi.org/";
-          $request_url = $url . $doi;
+          $doi = islandora_badges_get_doi($object);
+          if ($doi) {
+           // Set API endpoint URL
+           // @TODO: Add to admin form
+            $url = "https://api.oadoi.org/";
+            $request_url = $url . $doi;
 
          // Make the request and get results!
 
-          $result_json = file_get_contents($request_url);
-
-          $result_array = json_decode($result_json, TRUE);
-
-          $result_free_url = $result_array['results'][0]['free_fulltext_url'];
+            $result_json = file_get_contents($request_url);
+  
+            $result_array = json_decode($result_json, TRUE);
+  
+            $result_free_url = $result_array['results'][0]['free_fulltext_url'];
+          } 
         }
       }
     }

--- a/modules/islandora_oadoi/readme.md
+++ b/modules/islandora_oadoi/readme.md
@@ -23,7 +23,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 Configuration path is admin/islandora/tools/badges/wos (Administration > Islandora > Islandora Utility Modules > Islandora Badges Configuration > oaDOI).
 
 ## Styling
-
+The link text is enclosed in a block with the class "oadoi". This can be styled with CSS.
 
 ## Troubleshooting/Issues
 

--- a/modules/islandora_oadoi/readme.md
+++ b/modules/islandora_oadoi/readme.md
@@ -1,0 +1,48 @@
+# Islandora oaDOI
+
+## Introduction
+
+Islandora oaDOI provides block containing a link to an open-access version of a citation-only object. It uses the API from oadoi.org. 
+
+## Requirements
+
+This module requires the following modules/libraries:
+
+* [Islandora](https://github.com/islandora/islandora)
+* [Islandora Scholar](https://github.com/Islandora/islandora_scholar)
+* [Islandora Badges](../../)
+* [Tuque](https://github.com/islandora/tuque)
+* Probably a given for most repositories, but your objects must have a MODS datastream
+
+## Installation
+
+Install as usual, see [this](https://drupal.org/documentation/install/modules-themes/modules-7) for further information.
+
+## Configuration
+
+Configuration path is admin/islandora/tools/badges/wos (Administration > Islandora > Islandora Utility Modules > Islandora Badges Configuration > oaDOI).
+
+## Styling
+
+
+## Troubleshooting/Issues
+
+Having problems or solved a problem? Check out the Islandora google groups for a solution.
+
+* [Islandora Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora)
+* [Islandora Dev Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora-dev)
+
+## Maintainers/Sponsors
+
+Current maintainers:
+
+* [Brandon Weigel](https://github.com/bondjimbond)
+
+## Development
+
+If you would like to contribute to this module, please check out [CONTRIBUTING.md](CONTRIBUTING.md). In addition, we have helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the [Islandora.ca](http://islandora.ca) site.
+
+
+## License
+
+[GPLv3](http://www.gnu.org/licenses/gpl-3.0.txt)


### PR DESCRIPTION
# What does this Pull Request do?
New submodule: oaDOI
On citation-only objects (i.e. no PDF datastream), queries the oadoi.org API. If a free, open-access fulltext document is available, generates a block with a link to that document.
Makes use of the Islandora Badges config settings to determine which CModels get the block.

# How should this be tested?

* Enable the oaDOI module
* Enable the block
* Configure Islandora Badges to be enabled on various CModels
* See what occurs on objects with and without a DOI, within various CModels

# Interested parties
@mjordan @bondjimbond