### PR TITLE
Prevent incorrect self-referencing oaDOI link from displaying.

### DIFF
--- a/modules/islandora_oadoi/islandora_oadoi.module
+++ b/modules/islandora_oadoi/islandora_oadoi.module
@@ -64,7 +64,6 @@ function islandora_oadoi_block_view($delta = '') {
             $result_json = file_get_contents($request_url);
   
             $result_array = json_decode($result_json, TRUE);
-  
             $result_free_url = $result_array['results'][0]['free_fulltext_url'];
           } 
         }
@@ -73,8 +72,12 @@ function islandora_oadoi_block_view($delta = '') {
   }
 
   if (isset($result_free_url)){
-    $link_text = variable_get('islandora_oai_linktext', 'Link to PDF');
-    $to_render['content'] = '<div class="oadoi"><a href="' . $result_free_url . '" target="_blank">' . $link_text . '</a></div>';        
+    global $base_url;
+    // If the oaDOI URL points to the current website (a common error with their data), do not display block.
+    if (strpos($result_free_url, $base_url) !== 0) {
+      $link_text = variable_get('islandora_oai_linktext', 'Link to PDF');
+      $to_render['content'] = '<div class="oadoi"><a href="' . $result_free_url . '" target="_blank">' . $link_text . '</a></div>';        
+    }
   }
   return $to_render;
 }


### PR DESCRIPTION
# What does this Pull Request do?

oaDOI.org seems to automatically locate its links to free fulltext versions of papers, and sometimes makes mistakes. An object in your repository without a fulltext PDF might mistakenly end up in their database as the fulltext URL, in which case the oaDOI badge links back to the page you're viewing.

This PR checks whether the returned URL contains the site's base URL. If it does, no block is created.